### PR TITLE
Add STDIN console reader, refactor ban/chat services, and implemented more admin tools

### DIFF
--- a/Nuclei/Features/BanService.cs
+++ b/Nuclei/Features/BanService.cs
@@ -1,0 +1,22 @@
+﻿using NuclearOption.Networking;
+using Nuclei.Helpers;
+
+namespace Nuclei.Features;
+
+public static class BanService
+{
+    /// <summary>
+    ///     Verify that the player is not banned. If player in banlist, kick them off the server.
+    /// </summary>
+    /// <param name="player"> The player to verify. </param>
+    public static void VerifyNotBanned(Player player)
+    {
+        var steamId = player.SteamID;
+        if (NucleiConfig.IsBanned(steamId))
+        {
+            Nuclei.Logger?.LogInfo($"Player {player.PlayerName} is banned. Kicking...");
+            ChatService.SendChatMessage($"Player  {player.PlayerName} is banned.");
+            _ = Globals.NetworkManagerNuclearOptionInstance.KickPlayerAsync(player);
+        }
+    }
+}

--- a/Nuclei/Features/ChatService.cs
+++ b/Nuclei/Features/ChatService.cs
@@ -65,7 +65,8 @@ public static class ChatService
     /// <param name="player"> Player to use for chat message variables </param>
     public static void SendChatMessage(string message, Player? player = null)
     {
-        var actualMessage = message.PreProcessMessage(player);
+        var actualMessage = "{server_broadcast_name} " + message;
+        actualMessage = actualMessage.PreProcessMessage(player);
         
         if (!CanSend(actualMessage, ignoreRateLimit: true))
         {
@@ -73,22 +74,7 @@ public static class ChatService
             return;
         }
         
-        /* This uses the recipient as the "sender". TargetReceiveMessage requires this.
-           No way around it, devs have said that this will be changed in upcoming patch.
-         */
-        // TODO: review
-        foreach (var conn in Globals.MissionManagerInstance.Server.AuthenticatedPlayers)
-            try
-            {
-                if (!conn.TryGetPlayer<Player>(out var recipient) || recipient == null)
-                    continue;
-                 
-                Globals.ChatManagerInstance.TargetReceiveMessage(conn, actualMessage, recipient, true);
-            }
-            catch (Exception ex)
-            {
-                Nuclei.Logger?.LogError($"Broadcast to a connection failed: {ex}");
-            }
+        Globals.ChatManagerInstance.RpcServerMessage(actualMessage, false);
     }
 
     /// <summary>

--- a/Nuclei/Features/Commands/CommandService.cs
+++ b/Nuclei/Features/Commands/CommandService.cs
@@ -119,4 +119,30 @@ public static class CommandService
         
         return TryExecuteCommand(player, commandName, args);
     }
+    
+    /// <summary>
+    ///     Try to execute a command from the console.
+    /// </summary>
+    /// <param name="commandName"> The name of the command to execute. </param>
+    /// <param name="args"> The command arguments </param>
+    /// <returns> Whether the command was executed successfully. </returns>
+    public static bool TryExecuteCommand(string commandName, string[] args)
+    {
+        if (!TryGetCommand(commandName, out var command))
+        {
+            Nuclei.Logger?.LogWarning($"Command {commandName} not found");
+            return false;
+        }
+
+        if (command.Execute(args))
+        {
+            Nuclei.Logger?.LogInfo($"Command {commandName} executed successfully by console with argument(s): {string.Join(", ", args)}");
+        }
+        else
+        {
+            Nuclei.Logger?.LogWarning($"Command {commandName} failed to execute by console with argument(s): {string.Join(", ", args)}");
+        }
+   
+        return true;
+    }
 }

--- a/Nuclei/Features/Commands/ConsoleManager.cs
+++ b/Nuclei/Features/Commands/ConsoleManager.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using BepInEx.Logging;
+
+namespace Nuclei.Features.Commands
+{
+    internal sealed class ConsoleManager : IDisposable
+    {
+        private readonly SynchronizationContext _unityCtx;
+        private readonly Action<string, string[]> _onCommand;
+        private CancellationTokenSource? _cts;
+        private Thread? _thread;
+
+        public ConsoleManager(SynchronizationContext unityCtx, Action<string, string[]> onCommand)
+        {
+            _unityCtx = unityCtx ?? throw new ArgumentNullException(nameof(unityCtx));
+            _onCommand = onCommand ?? throw new ArgumentNullException(nameof(onCommand));
+        }
+
+        public void Start()
+        {
+            if (_thread != null) return;
+
+            _cts = new CancellationTokenSource();
+            _thread = new Thread(() => StdinLoop(_cts.Token))
+            {
+                IsBackground = true,
+                Name = "Nuclei-StdInReader"
+            };
+            _thread.Start();
+            Nuclei.Logger?.LogInfo("ConsoleManager: STDIN reader started.");
+        }
+
+        public void Stop()
+        {
+            try
+            {
+                _cts?.Cancel();
+                if (_thread != null && _thread.IsAlive)
+                    _thread.Join(250); 
+            }
+            catch { /* swallow */ }
+            finally
+            {
+                _thread = null;
+                _cts = null;
+                Nuclei.Logger?.LogInfo("ConsoleManager: STDIN reader stopped.");
+            }
+        }
+
+        private void StdinLoop(CancellationToken token)
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    
+                    var line = Console.ReadLine();
+                    if (line == null)
+                    {
+                        Nuclei.Logger?.LogWarning("ConsoleManager: STDIN closed (ReadLine returned null). Stopping.");
+                        break;
+                    }
+
+                    line = line.Trim();
+                    if (line.Length == 0)
+                        continue;
+
+                    var args = SplitArgs(line);
+                    
+                    _unityCtx.Post(_ => _onCommand(line, args), null);
+                }
+            }
+            catch (Exception ex)
+            {
+                Nuclei.Logger?.LogError($"ConsoleManager: STDIN loop crashed: {ex}");
+            }
+        }
+
+        public void Dispose() => Stop();
+
+        private static string[] SplitArgs(string input)
+        {
+            // Matches "quoted strings" or bare tokens
+            var matches = Regex.Matches(input, "\"([^\"]*)\"|([^\\s]+)");
+            return matches.Cast<Match>()
+                   .Select(m => m.Groups[1].Success ? m.Groups[1].Value : m.Groups[2].Value)
+                   .ToArray();
+        }
+    }
+}

--- a/Nuclei/Features/Commands/DefaultCommands/BanCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/BanCommand.cs
@@ -7,7 +7,7 @@ using Nuclei.Helpers;
 namespace Nuclei.Features.Commands.DefaultCommands;
 
 /// <summary>
-///     Command to kick a player from the server.
+///     Command to ban a player from the server.
 /// </summary>
 public class BanCommand(ConfigFile config) : PermissionConfigurableCommand(config)
 {
@@ -42,6 +42,24 @@ public class BanCommand(ConfigFile config) : PermissionConfigurableCommand(confi
         Nuclei.Logger?.LogWarning($"Player {target} not found.");
         return false;
     }
-    
+
+    public override bool Execute(string[] args)
+    {
+        var target = args[0];
+
+        if (PlayerUtils.TryFindPlayer(target, out var targetPlayer))
+        {
+
+            NucleiConfig.AddBannedPlayer(targetPlayer!.SteamID.ToString());
+            _ = Globals.NetworkManagerNuclearOptionInstance.KickPlayerAsync(targetPlayer);
+            Nuclei.Logger?.LogInfo($"Player {target} banned from the server.");
+            return true;
+        }
+
+        Nuclei.Logger?.LogWarning($"Player {target} not found.");
+        return false;
+    }
+
+
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Moderator;
 }

--- a/Nuclei/Features/Commands/DefaultCommands/BanSteamIDCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/BanSteamIDCommand.cs
@@ -1,0 +1,41 @@
+﻿using BepInEx.Configuration;
+using NuclearOption.Networking;
+using Nuclei.Enums;
+using Nuclei.Helpers;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace Nuclei.Features.Commands.DefaultCommands;
+
+/// <summary>
+///     Command to ban a steam id from the server. Useful if player is offline.
+/// </summary>
+public class BanSteamIDCommand(ConfigFile config) : PermissionConfigurableCommand(config)
+{
+    public override string Name { get; } = "bansteamid";
+    public override string Description { get; } = "Bans a steamid from the server.";
+    public override string Usage { get; } = "bansteamid <steamid>";
+
+    public override bool Validate(Player player, string[] args)
+    {
+        return args.Length == 1;
+    }
+
+    public override bool Execute(Player player, string[] args)
+    {
+        var target = args[0];
+        NucleiConfig.AddBannedPlayer(target.ToString());
+        Nuclei.Logger?.LogInfo($"SteamID {target} banned from the server.");
+        return true;
+    }
+
+    public override bool Execute(string[] args)
+    {
+        var target = args[0];
+        NucleiConfig.AddBannedPlayer(target.ToString());
+        Nuclei.Logger?.LogInfo($"SteamID {target} banned from the server.");
+        return true;
+    }
+
+
+    public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Moderator;
+}

--- a/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
@@ -41,5 +41,26 @@ public class HelpCommand(ConfigFile config) : PermissionConfigurableCommand(conf
         return true;
     }
     
+    public override bool Execute(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            var accessibleCommands = CommandService.GetCommands().Where(c => c.PermissionLevel <= PermissionLevel.Owner).ToList();
+            var commandNames = accessibleCommands.Select(c => c.Name).ToList();
+            Nuclei.Logger?.LogInfo($"You have access to the following commands: {string.Join(", ", commandNames)}");
+            return true;
+        }
+        
+        var commandName = args[0];
+        if (!CommandService.TryGetCommand(commandName, out var command))
+        {
+            Nuclei.Logger?.LogInfo($"Command '{commandName}' not found.");
+            return true;
+        }
+        
+        Nuclei.Logger?.LogInfo($"Command '{command.Name}': {command.Description}");
+        return true;
+    }
+    
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Everyone;
 }

--- a/Nuclei/Features/Commands/DefaultCommands/KickCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/KickCommand.cs
@@ -43,6 +43,22 @@ public class KickCommand(ConfigFile config) : PermissionConfigurableCommand(conf
         Nuclei.Logger?.LogWarning($"Player {target} not found.");
         return false;
     }
+    
+    public override bool Execute(string[] args)
+    {
+        var target = args[0];
+
+        if (PlayerUtils.TryFindPlayer(target, out var targetPlayer))
+        {
+            _ = Globals.NetworkManagerNuclearOptionInstance.KickPlayerAsync(targetPlayer);
+            Nuclei.Logger?.LogInfo($"Player {target} was kicked from the server.");
+            ChatService.SendChatMessage($"Player {target} was kicked from the server.");
+            return true;
+        }
+
+        Nuclei.Logger?.LogWarning($"Player {target} not found.");
+        return false;
+    }
 
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Moderator;
 }

--- a/Nuclei/Features/Commands/DefaultCommands/ListCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/ListCommand.cs
@@ -1,0 +1,63 @@
+﻿using BepInEx.Configuration;
+using Mirage;
+using NuclearOption.Networking;
+using Nuclei.Enums;
+using Nuclei.Helpers;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace Nuclei.Features.Commands.DefaultCommands;
+
+/// <summary>
+///     Command to list currently connected players.    
+/// </summary>
+public class ListCommand(ConfigFile config) : PermissionConfigurableCommand(config)
+{
+    public override string Name { get; } = "list";
+    public override string Description { get; } = "List all connected players.";
+    public override string Usage { get; } = "list";
+
+    public override bool Validate(Player player, string[] args)
+    {
+        return true;
+    }
+
+    public override bool Execute(Player player, string[] args)
+    {
+        var players = Globals.AuthenticatedPlayers;
+        var playerNames = "";
+        foreach (INetworkPlayer item in players)
+        {
+            Player p;
+            item.TryGetPlayer(out p);
+            if (p != null)
+            {
+                playerNames += $"{p.PlayerName}, ";
+            }
+        }
+        string finalMessage = $"[{players.Count - 1}] ";
+        finalMessage += playerNames;
+        ChatService.SendPrivateChatMessage($"{finalMessage}", player);
+        return true;
+    }
+
+    public override bool Execute(string[] args)
+    {
+        var players = Globals.AuthenticatedPlayers;
+        var playerNames = "";
+        foreach (INetworkPlayer item in players)
+        {
+            Player p;
+            item.TryGetPlayer(out p);
+            if (p != null)
+            {
+                playerNames += $"{p.PlayerName}, ";
+            }
+        }
+        string finalMessage = $"[{players.Count - 1}] ";
+        finalMessage += playerNames;
+        Nuclei.Logger?.LogInfo($"{finalMessage}");
+        return true;
+    }
+
+    public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Everyone;
+}

--- a/Nuclei/Features/Commands/DefaultCommands/NewMissionCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/NewMissionCommand.cs
@@ -26,6 +26,11 @@ public class NewMissionCommand(ConfigFile config) : PermissionConfigurableComman
     {
         throw new NotImplementedException();
     }
+    
+    public override bool Execute(string[] args)
+    {
+        throw new NotImplementedException();
+    }
 
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Admin;
 }

--- a/Nuclei/Features/Commands/DefaultCommands/NextMissionCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/NextMissionCommand.cs
@@ -1,0 +1,33 @@
+﻿using BepInEx.Configuration;
+using Cysharp.Threading.Tasks;
+using NuclearOption.Networking;
+using NuclearOption.Networking.Lobbies;
+using NuclearOption.SavedMission;
+using Nuclei.Enums;
+using Nuclei.Helpers;
+using System;
+
+namespace Nuclei.Features.Commands.DefaultCommands;
+
+public class NextMissionCommand(ConfigFile config) : PermissionConfigurableCommand(config)
+{
+    public override string Name => "nextmission";
+    public override string Description => "Ends the current mission and starts the next one in the rotation.";
+    public override string Usage => "nextmission";
+    public override PermissionLevel DefaultPermissionLevel => PermissionLevel.Moderator;
+
+
+    public override bool Validate(Player player, string[] args) => true;
+
+    public override bool Execute(Player player, string[] args)
+    {
+        MissionService.StartNextMission(player); 
+        return true;
+    }
+
+    public override bool Execute(string[] args)
+    {
+        MissionService.StartNextMission(null); 
+        return true;
+    }
+}

--- a/Nuclei/Features/Commands/DefaultCommands/SayCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/SayCommand.cs
@@ -26,5 +26,12 @@ public class SayCommand(ConfigFile config) : PermissionConfigurableCommand(confi
         return true;
     }
     
+    public override bool Execute(string[] args)
+    {
+        var message = string.Join(" ", args);
+        ChatService.SendChatMessage($"{message}");
+        return true;
+    }
+    
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Moderator;
 }

--- a/Nuclei/Features/Commands/DefaultCommands/SetPermissionLevelCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/SetPermissionLevelCommand.cs
@@ -54,5 +54,37 @@ public class SetPermissionLevelCommand(ConfigFile config) : PermissionConfigurab
         return false;
     }
     
+    public override bool Execute(string[] args)
+    {
+        var target = args[0];
+        PermissionLevelUtils.TryParsePermissionLevel(args[1], out var permissionLevel);
+
+        if (PlayerUtils.TryFindPlayer(target, out var targetPlayer))
+        {
+            var targetSteamID = targetPlayer!.SteamID.ToString();
+            switch (permissionLevel)
+            {
+                case PermissionLevel.Admin:
+                    NucleiConfig.AddAdmin(targetSteamID);
+                    NucleiConfig.RemoveModerator(targetSteamID);
+                    break;
+                case PermissionLevel.Moderator:
+                    NucleiConfig.RemoveAdmin(targetSteamID);
+                    NucleiConfig.AddModerator(targetSteamID);
+                    break;
+                default:
+                case PermissionLevel.Everyone:
+                    NucleiConfig.RemoveAdmin(targetSteamID);
+                    NucleiConfig.RemoveModerator(targetSteamID);
+                    break;
+            }
+            Nuclei.Logger?.LogInfo($"Set permission level of {target} to {permissionLevel}.");
+            return true;
+        }
+
+        Nuclei.Logger?.LogWarning($"Player {target} not found.");
+        return false;
+    }
+    
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Owner;
 }

--- a/Nuclei/Features/Commands/DefaultCommands/StopCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/StopCommand.cs
@@ -26,6 +26,12 @@ public class StopCommand(ConfigFile config) : PermissionConfigurableCommand(conf
         Globals.NetworkManagerNuclearOptionInstance.Server.Stop();
         return true;
     }
+    public override bool Execute( string[] args)
+    {
+        Nuclei.Logger?.LogInfo("Stopping server...");
+        Globals.NetworkManagerNuclearOptionInstance.Server.Stop();
+        return true;
+    }
     
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Owner;
 }

--- a/Nuclei/Features/Commands/ICommand.cs
+++ b/Nuclei/Features/Commands/ICommand.cs
@@ -37,10 +37,17 @@ public interface ICommand
     bool Validate(Player player, string[] args);
 
     /// <summary>
-    ///     The command action.
+    ///     The command action executed by a plyer.
     /// </summary>
     /// <param name="player"> The player executing the command. </param>
     /// <param name="args"> The command arguments. </param>
     /// <returns> Whether the command was executed successfully. </returns>
     bool Execute(Player player, string[] args);
+    
+    /// <summary>
+    ///     The command action executed by the console.
+    /// </summary>
+    /// <param name="args"> The command arguments. </param>
+    /// <returns> Whether the command was executed successfully. </returns>
+    bool Execute(string[] args);
 }

--- a/Nuclei/Features/Commands/PermissionConfigurableCommand.cs
+++ b/Nuclei/Features/Commands/PermissionConfigurableCommand.cs
@@ -25,6 +25,9 @@ public abstract class PermissionConfigurableCommand : ICommand
 
     /// <inheritdoc />
     public abstract bool Execute(Player player, string[] args);
+    
+    /// <inheritdoc />
+    public abstract bool Execute(string[] args);
 
     /// <inheritdoc />
     public PermissionLevel PermissionLevel => PermissionLevelConfig.Value;

--- a/Nuclei/Features/MissionService.cs
+++ b/Nuclei/Features/MissionService.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
+using NuclearOption.Networking;
+using NuclearOption.Networking.Lobbies;
 using NuclearOption.SavedMission;
 using NuclearOption.SavedMission.ObjectiveV2;
 using Nuclei.Enums;
@@ -204,5 +207,67 @@ public static class MissionService
         mission = GetMission(PreselectedMissionKey.Value)!;
         PreselectedMissionKey = null;
         return true;
+    }
+    
+    
+    // TODO: Deconstruct this into smaller, reusable functions
+    /// <summary>
+    ///     Starts the next mission in the mission rotation.
+    /// </summary>
+    public static async void StartNextMission(Player? player)
+    {
+        
+        try
+        {
+            var dsm = Globals.DedicatedServerManagerInstance;
+            if (dsm == null)
+            {
+                Nuclei.Logger?.LogWarning("dsm is null");
+                return;
+            }
+
+            var mr = dsm.missionRotation;
+            if (mr == null)
+            {
+                Nuclei.Logger?.LogWarning("missionRotation is null");
+                return;
+            }
+
+            var nextOpt = mr.GetNext();
+            if (!nextOpt.Key.TryGetKey(out var key))
+            {
+                Nuclei.Logger?.LogWarning("Error: could not resolve mission key.");
+                return;
+            }
+
+            if (!MissionSaveLoad.TryLoad(key, out var mission, out var err))
+            {
+                Nuclei.Logger?.LogWarning($"Load failed: {err}");
+                return;
+            }
+
+            Nuclei.Logger?.LogInfo($"Loading next mission: {mission?.Name ?? "<unnamed>"}");
+            if (player != null) ChatService.SendPrivateChatMessage("Loading next mission...", player);
+
+            // Switch to main thread for Unity scene/lobby ops
+            await UniTask.SwitchToMainThread();
+
+            dsm.UpdateLobby(mission, false);
+            var ok = await dsm.LoadNext(mission);
+            if (!ok)
+            {
+                if (player != null) Nuclei.Logger?.LogError("Failed to load next mission.");
+                return;
+            }
+
+            dsm.keyValues.SetKeyValue("start_time", LobbyInstance.CreateStartTime());
+            dsm.currentMission = mission;
+            dsm.currentMissionOption = nextOpt;
+        }
+        catch (Exception e)
+        {
+            Nuclei.Logger?.LogError(e);
+            if (player != null) Nuclei.Logger?.LogError("Unexpected error while loading mission.");
+        }
     }
 }

--- a/Nuclei/Features/NucleiConfig.cs
+++ b/Nuclei/Features/NucleiConfig.cs
@@ -83,6 +83,15 @@ public static class NucleiConfig
 
     internal static ConfigEntry<string>? CommandPrefix;
     internal const string DefaultCommandPrefix = "/";
+
+    internal static ConfigEntry<bool>? UseStaffPrefix;
+    internal const bool DefaultUseStaffPrefix = true;
+
+    internal static ConfigEntry<string>? StaffPrefix;
+    internal const string DefaultStaffPrefix = "<color=#FFD700>[Staff]</color>";
+
+    internal static ConfigEntry<string>? ServerBroadcastName;
+    internal const string DefaultServerBroadcastName = "<color=#99182e>[Nuclei]</color>";
     
     internal static List<string> ModeratorsList => Moderators!.Value.Split(';').Where(m => !string.IsNullOrWhiteSpace(m)).ToList();
     
@@ -164,6 +173,18 @@ public static class NucleiConfig
 
         CommandPrefix = config.Bind(GeneralSection, "CommandPrefix", DefaultCommandPrefix, "What to use as the command prefix (the character at the start of a command).");
         Nuclei.Logger?.LogDebug($"CommandPrefix: {CommandPrefix.Value}");
+
+        UseStaffPrefix = config.Bind(GeneralSection, "UseStaffPrefix", DefaultUseStaffPrefix,
+            "Whether to use staff prefix or not.");
+        Nuclei.Logger?.LogDebug($"UseStaffPrefix: {UseStaffPrefix.Value}");
+
+        StaffPrefix = config.Bind(GeneralSection, "StaffPrefix", DefaultStaffPrefix,
+            "The prefix added in-front of the usernames of Moderators, Admins and the Owner.");
+        Nuclei.Logger?.LogDebug($"StaffTag: {StaffPrefix.Value}");
+
+        ServerBroadcastName = config.Bind(GeneralSection, "ServerBroadcastName", DefaultServerBroadcastName,
+            "The name that appears in the chat when the server broadcasts a message.");
+        Nuclei.Logger?.LogDebug($"ServerBroadcastName: {ServerBroadcastName}");
         
         Nuclei.Logger?.LogDebug("Loaded settings!");
     }
@@ -212,6 +233,18 @@ public static class NucleiConfig
         {
             Nuclei.Logger?.LogWarning("CommandPrefix must be a single character! Resetting to default value.");
             CommandPrefix.Value = DefaultCommandPrefix;
+        }
+
+        if (UseStaffPrefix!.Value && StaffPrefix!.Value.Length == 0)
+        {
+            Nuclei.Logger?.LogWarning("UseStaffPrefix is enabled, however no StaffPrefix has been set. Resetting to default value.");
+            StaffPrefix.Value = DefaultStaffPrefix;
+        }
+
+        if (ServerBroadcastName!.Value.Length == 0)
+        {
+            Nuclei.Logger?.LogWarning("No ServerBroadcastName has been set. Resetting to default value.");
+            ServerBroadcastName.Value = DefaultServerBroadcastName;
         }
         
         ValidateForUserErrors();

--- a/Nuclei/Helpers/DynamicPlaceholderUtils.cs
+++ b/Nuclei/Helpers/DynamicPlaceholderUtils.cs
@@ -1,4 +1,5 @@
 using NuclearOption.Networking;
+using Nuclei.Features;
 
 namespace Nuclei.Helpers;
 
@@ -71,6 +72,11 @@ public static class DynamicPlaceholderUtils
     ///     Placeholder for the server name.
     /// </summary>
     public const string ServerName = "{server_name}";
+    
+    /// <summary>
+    ///     Placeholder for the message broadcaster name.
+    /// </summary>
+    public const string ServerBroadcastName = "{server_broadcast_name}";
 
     /// <summary>
     ///     Replaces dynamic placeholders in a string with the appropriate values.
@@ -87,6 +93,8 @@ public static class DynamicPlaceholderUtils
             original = original.Replace(PlayerNameCensored, player.GetNameOrCensored());
             original = original.Replace(SteamID, player.SteamID.ToString());
         }
+        
+        original = original.Replace(ServerBroadcastName, NucleiConfig.ServerBroadcastName!.Value);
         /*
         original = original.Replace(MissionName, MissionService.CurrentMission!.Name);
         if (MissionService.CurrentMission!.factions.Count > 0)

--- a/Nuclei/Helpers/Globals.cs
+++ b/Nuclei/Helpers/Globals.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Mirage;
 using NuclearOption.Chat;
+using NuclearOption.DedicatedServer;
 using NuclearOption.Networking;
 
 namespace Nuclei.Helpers;
@@ -35,4 +36,10 @@ public static class Globals
     ///     Get a read-only list of all authenticated players.
     /// </summary>
     public static IReadOnlyList<INetworkPlayer> AuthenticatedPlayers => NetworkManagerNuclearOptionInstance.Server.AuthenticatedPlayers;
+    
+    /// <summary>
+    ///     Get the instance of the <see cref="DedicatedServerManager" /> class.
+    /// </summary>
+    public static DedicatedServerManager DedicatedServerManagerInstance => NetworkManagerNuclearOptionInstance.DedicatedServerManager ?? throw new NullReferenceException("No Dedicated Server found");   
+
 }

--- a/Nuclei/Helpers/PlayerUtils.cs
+++ b/Nuclei/Helpers/PlayerUtils.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Mirage;
 using NuclearOption.Networking;
+using Nuclei.Features;
 
 namespace Nuclei.Helpers;
 
@@ -40,7 +42,37 @@ public static class PlayerUtils
     /// <returns></returns>
     public static bool TryFindPlayer(string playerName, out Player? playerObject)
     {
-        playerObject = Globals.AuthenticatedPlayers.FirstOrDefault(p => string.Equals(p.GetPlayer()?.PlayerName, playerName, StringComparison.CurrentCultureIgnoreCase))?.GetPlayer();
+        playerObject = Globals.AuthenticatedPlayers.FirstOrDefault(p => string.Equals(StripStaffPrefix(p.GetPlayer()?.PlayerName ?? ""), StripStaffPrefix(playerName), StringComparison.CurrentCultureIgnoreCase))?.GetPlayer();
         return playerObject != null;
+    }
+    
+    /// <summary>
+    ///     Utility function to strip a player name of the staff tag, if they have it.
+    /// </summary>
+    /// <param name="playerName"> The player name. </param>
+    /// <returns>Actual playername.</returns>
+    private static string StripStaffPrefix(string playerName)
+    {
+        if (string.IsNullOrEmpty(playerName))
+            return playerName;
+
+        var pattern = $@"^{Regex.Escape(NucleiConfig.StaffPrefix!.Value)}\s*";
+        var cleanName = Regex.Replace(playerName, pattern, "", RegexOptions.IgnoreCase);
+
+        return cleanName;
+    }
+
+    /// <summary>
+    ///     Apply or remove the staff tag based on player permission level.
+    /// </summary>
+    /// <param name="playerObject"> The Player object. </param>
+    /// <returns></returns>
+    public static void ApplyOrRemoveStaffTag(Player playerObject)
+    {
+        if (!NucleiConfig.UseStaffPrefix!.Value || (!NucleiConfig.IsAdmin(playerObject.SteamID) &&
+                                                   !NucleiConfig.IsOwner(playerObject.SteamID) &&
+                                                   !NucleiConfig.IsModerator(playerObject.SteamID))) return;
+        var newName = $"{NucleiConfig.StaffPrefix!.Value} {playerObject.PlayerName}";
+        playerObject.PlayerName = newName;
     }
 }

--- a/Nuclei/Patches/MessageManagerPatches.cs
+++ b/Nuclei/Patches/MessageManagerPatches.cs
@@ -2,7 +2,6 @@ using HarmonyLib;
 using NuclearOption.Networking;
 using Nuclei.Events;
 using Nuclei.Features;
-using Nuclei.Helpers;
 
 namespace Nuclei.Patches;
 
@@ -15,15 +14,6 @@ internal static class MessageManagerPatches
     [HarmonyPatch(nameof(MessageManager.JoinMessage))]
     private static void JoinMessagePostfix(Player joinedPlayer)
     {
-        // TODO: move ban check to a dedicated service, hook into OnPlayerJoined event (or earlier?)
-        var steamId = joinedPlayer.SteamID;
-        if (NucleiConfig.IsBanned(steamId))
-        {
-            Nuclei.Logger?.LogInfo($"Player {joinedPlayer.PlayerName} is banned. Kicking...");
-            _ = Globals.NetworkManagerNuclearOptionInstance.KickPlayerAsync(joinedPlayer);
-            return;
-        }
-
         Nuclei.Logger?.LogInfo($"{joinedPlayer.PlayerName} joined the game");
         ChatService.SendChatMessage(NucleiConfig.WelcomeMessage!.Value, joinedPlayer);
         


### PR DESCRIPTION
- Added first draft STDIN reader for running server commands directly from console.
- Moved ban logic to BanService; now properly triggered via PlayerJoined event.
- Rewrote ChatService to use RpcServerMessage for proper server broadcasts.
- Added /nextmission, /bansteamid, and /list admin commands.
- Implemented configurable staff tag prefix for admin/moderator/owner roles.
- Some code cleanup.