### PR TITLE
Initialize TimeService & Implement MoTD timer | Fix missionTime to MissionTime

### DIFF
--- a/Nuclei/Events/ServerEvents.cs
+++ b/Nuclei/Events/ServerEvents.cs
@@ -1,4 +1,5 @@
 using System;
+using Nuclei.Features;
 
 namespace Nuclei.Events;
 
@@ -15,6 +16,7 @@ public static class ServerEvents
     internal static void OnServerStarted()
     {
         ServerStarted?.Invoke();
+        TimeService.Initialize();
     }
 
     /// <summary>

--- a/Nuclei/Features/MissionService.cs
+++ b/Nuclei/Features/MissionService.cs
@@ -47,7 +47,7 @@ public static class MissionService
     /// <summary>
     ///     The current mission time.
     /// </summary>
-    public static float CurrentMissionTime => Globals.MissionManagerInstance.missionTime;
+    public static float CurrentMissionTime => Globals.MissionManagerInstance.MissionTime;
 
     /// <summary>
     ///     Gets all Mission Keys as an IEnumerable.

--- a/Nuclei/Features/TimeService.cs
+++ b/Nuclei/Features/TimeService.cs
@@ -54,6 +54,15 @@ public class TimeService : MonoBehaviour
         _lastTime = currentTime;
         
         TimeEvents.OnEverySecond();
+
+        
+        // MoTD
+        var motdFreq = NucleiConfig.MotDFrequency!.Value;
+        if (currentTime % motdFreq == 0)
+        {
+            ChatService.SendMotD();
+        }
+
         if (currentTime % 3600 == 0)
         {
             TimeEvents.OnEveryHour();


### PR DESCRIPTION
TimeService wasn't initialized, so i made it do so. Implemented MoTD timer as well so that MoTD correctly displays every x seconds as stated in the NucleiConfig.

missionTime variable has switched to MissionTime, so i changed that as well

**Merge PR #28 first**