### PR TITLE
Implement rank catchup system | Improve Help command

### DIFF
--- a/Nuclei/Events/PlayerEvents.cs
+++ b/Nuclei/Events/PlayerEvents.cs
@@ -1,5 +1,6 @@
 using System;
 using NuclearOption.Networking;
+using Nuclei.Features;
 
 namespace Nuclei.Events;
 
@@ -16,6 +17,7 @@ public static class PlayerEvents
     internal static void OnPlayerJoined(Player e)
     {
         PlayerJoined?.Invoke(e);
+        RankCatchUpService.CatchUpPlayer(e);
     }
 
     /// <summary>

--- a/Nuclei/Events/PlayerEvents.cs
+++ b/Nuclei/Events/PlayerEvents.cs
@@ -17,7 +17,7 @@ public static class PlayerEvents
     internal static void OnPlayerJoined(Player e)
     {
         PlayerJoined?.Invoke(e);
-        RankCatchUpService.CatchUpPlayer(e);
+        if (NucleiConfig.RankCatchUp!.Value) RankCatchUpService.CatchUpPlayer(e);
     }
 
     /// <summary>

--- a/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
@@ -43,6 +43,7 @@ public class HelpCommand(ConfigFile config) : PermissionConfigurableCommand(conf
         }
         
         ChatService.SendPrivateChatMessage($"Command '{command.Name}': {command.Description}", player);
+        ChatService.SendPrivateChatMessage($"Usage: {command.Usage}", player);
         return true;
     }
     

--- a/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
@@ -25,12 +25,12 @@ public class HelpCommand(ConfigFile config) : PermissionConfigurableCommand(conf
         if (args.Length == 0)
         {
             var accessibleCommands = CommandService.GetCommands().Where(c => c.PermissionLevel <= CommandService.GetPlayerPermissionLevel(player)).ToList();
-            var commandNames = accessibleCommands.Select(c => c.Name).ToList();
+            var commands = accessibleCommands.ToList();
             ChatService.SendPrivateChatMessage($"You have access to the following commands:", player);
             ChatService.SendPrivateChatMessage($"(For more help, type {NucleiConfig.CommandPrefixChar}{Usage})", player);
-            foreach (var cmd in commandNames)
+            foreach (var cmd in commands)
             {
-                ChatService.SendPrivateChatMessage($"{cmd}", player);
+                ChatService.SendPrivateChatMessage($"{cmd.Name} - {cmd.Description}", player);
             }
             return true;
         }

--- a/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/HelpCommand.cs
@@ -26,7 +26,12 @@ public class HelpCommand(ConfigFile config) : PermissionConfigurableCommand(conf
         {
             var accessibleCommands = CommandService.GetCommands().Where(c => c.PermissionLevel <= CommandService.GetPlayerPermissionLevel(player)).ToList();
             var commandNames = accessibleCommands.Select(c => c.Name).ToList();
-            ChatService.SendPrivateChatMessage($"You have access to the following commands: {string.Join(", ", commandNames)}", player);
+            ChatService.SendPrivateChatMessage($"You have access to the following commands:", player);
+            ChatService.SendPrivateChatMessage($"(For more help, type {NucleiConfig.CommandPrefixChar}{Usage})", player);
+            foreach (var cmd in commandNames)
+            {
+                ChatService.SendPrivateChatMessage($"{cmd}", player);
+            }
             return true;
         }
         

--- a/Nuclei/Features/NucleiConfig.cs
+++ b/Nuclei/Features/NucleiConfig.cs
@@ -83,6 +83,8 @@ public static class NucleiConfig
 
     internal static ConfigEntry<string>? CommandPrefix;
     internal const string DefaultCommandPrefix = "/";
+    internal static ConfigEntry<bool>? RankCatchUp;
+    internal const bool DefaultRankCatchUp = true;
     
     internal static List<string> ModeratorsList => Moderators!.Value.Split(';').Where(m => !string.IsNullOrWhiteSpace(m)).ToList();
     
@@ -164,6 +166,9 @@ public static class NucleiConfig
 
         CommandPrefix = config.Bind(GeneralSection, "CommandPrefix", DefaultCommandPrefix, "What to use as the command prefix (the character at the start of a command).");
         Nuclei.Logger?.LogDebug($"CommandPrefix: {CommandPrefix.Value}");
+
+        RankCatchUp = config.Bind(GeneralSection, "RankCatchUp", DefaultRankCatchUp, "Whether to enable the rank catch-up system, which gives players a rank and allocation boost based on how far into the mission they join.");
+        Nuclei.Logger?.LogDebug($"RankCatchUp: {RankCatchUp.Value}");
         
         Nuclei.Logger?.LogDebug("Loaded settings!");
     }

--- a/Nuclei/Features/RankCatchUpService.cs
+++ b/Nuclei/Features/RankCatchUpService.cs
@@ -7,9 +7,15 @@ public class RankCatchUpService
 {
     public static void CatchUpPlayer(Player player)
     {
+        if (player.PlayerRank != 0) 
+        {
+            Nuclei.Logger?.LogDebug($"Player {player.PlayerName} already has rank {player.PlayerRank}, skipping catch-up.");
+            return;
+        }
         var currentMissionTime = Time.timeSinceLevelLoad;
         var maxMissionTime = Globals.DedicatedServerManagerInstance.CurrentMissionOption.MaxTime;
         var percentComplete = currentMissionTime / maxMissionTime;
+
 
         if (percentComplete < .20) return;
         else if (percentComplete >= .80) 

--- a/Nuclei/Features/RankCatchUpService.cs
+++ b/Nuclei/Features/RankCatchUpService.cs
@@ -7,10 +7,9 @@ public class RankCatchUpService
 {
     public static void CatchUpPlayer(Player player)
     {
-        if (player.PlayerRank != 0) 
+        if (player.GetAuthData().SaveData.Faction != null)
         {
-            Nuclei.Logger?.LogDebug($"Player {player.PlayerName} already has rank {player.PlayerRank}, skipping catch-up.");
-            return;
+            return; // Means that they already joined the server. No double-dipping!
         }
         var currentMissionTime = Time.timeSinceLevelLoad;
         var maxMissionTime = Globals.DedicatedServerManagerInstance.CurrentMissionOption.MaxTime;
@@ -41,7 +40,7 @@ public class RankCatchUpService
         else if (percentComplete >= .20) 
         {
             player.SetRank(1, false);
-            player.SetAllocation(player.Allocation + 100);
+            player.SetAllocation(player.Allocation + 100f);
         }
     }
 }

--- a/Nuclei/Features/RankCatchUpService.cs
+++ b/Nuclei/Features/RankCatchUpService.cs
@@ -1,0 +1,41 @@
+using NuclearOption.Networking;
+using Nuclei.Helpers;
+using UnityEngine;
+namespace Nuclei.Features;
+
+public class RankCatchUpService
+{
+    public static void CatchUpPlayer(Player player)
+    {
+        var currentMissionTime = Time.timeSinceLevelLoad;
+        var maxMissionTime = Globals.DedicatedServerManagerInstance.CurrentMissionOption.MaxTime;
+        var percentComplete = currentMissionTime / maxMissionTime;
+
+        if (percentComplete < .20) return;
+        else if (percentComplete >= .80) 
+        {
+            player.SetRank(5, false);
+            player.SetAllocation(player.Allocation + 300f);
+        }
+        else if (percentComplete >= .60) 
+        {
+            player.SetRank(4, false);
+            player.SetAllocation(player.Allocation + 250f);
+        }
+        else if (percentComplete >= .40) 
+        {
+            player.SetRank(3, false);
+            player.SetAllocation(player.Allocation + 200f);
+        }
+        else if (percentComplete >= .40) 
+        {
+            player.SetRank(2, false);
+            player.SetAllocation(player.Allocation + 150f);
+        }
+        else if (percentComplete >= .20) 
+        {
+            player.SetRank(1, false);
+            player.SetAllocation(player.Allocation + 100);
+        }
+    }
+}

--- a/Nuclei/Features/RankCatchUpService.cs
+++ b/Nuclei/Features/RankCatchUpService.cs
@@ -13,34 +13,39 @@ public class RankCatchUpService
         }
         var currentMissionTime = Time.timeSinceLevelLoad;
         var maxMissionTime = Globals.DedicatedServerManagerInstance.CurrentMissionOption.MaxTime;
-        var percentComplete = currentMissionTime / maxMissionTime;
+        var percentComplete = (currentMissionTime / maxMissionTime) * 2;
 
+        var rank = 0;
+        var allocation = 0f;
 
         if (percentComplete < .20) return;
-        else if (percentComplete >= .80) 
+        else if (percentComplete >= .80)
         {
-            player.SetRank(5, false);
-            player.SetAllocation(player.Allocation + 300f);
+            rank = 5;
+            allocation = 400f;
         }
         else if (percentComplete >= .60) 
         {
-            player.SetRank(4, false);
-            player.SetAllocation(player.Allocation + 250f);
+            rank = 4;
+            allocation = 350f;
         }
         else if (percentComplete >= .40) 
         {
-            player.SetRank(3, false);
-            player.SetAllocation(player.Allocation + 200f);
+            rank = 3;
+            allocation = 300f;
         }
         else if (percentComplete >= .40) 
         {
-            player.SetRank(2, false);
-            player.SetAllocation(player.Allocation + 150f);
+            rank = 2;
+            allocation = 250f;
         }
         else if (percentComplete >= .20) 
         {
-            player.SetRank(1, false);
-            player.SetAllocation(player.Allocation + 100f);
+            rank = 1;
+            allocation = 200f;
         }
+        player.SetRank(rank, false);
+        player.SetAllocation(player.Allocation + allocation);
+        ChatService.SendPrivateChatMessage($"Late join - You have been promoted to Rank {rank} with +${allocation}m", player);
     }
 }


### PR DESCRIPTION
**Requires #28** 

This is simple. As mission time passes, players that join will get a head start in rank and funds based on the % of max mission time.

Help command now doesn't cut out due to char limit

TODO: Be able to toggle via config file - ✅ Done

View https://github.com/jmarmstrong1207/Nuclei/tree/merge-test branch for implementation of all these PRs