### PR TITLE
Correctly Reset fetched missions after vote handling

### DIFF
--- a/Nuclei/Features/Commands/DefaultCommands/VoteMissionCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/VoteMissionCommand.cs
@@ -66,14 +66,16 @@ public class VoteMissionCommand(ConfigFile config) : PermissionConfigurableComma
         else
         {
             ChatService.SendPrivateChatMessage("Cannot start a new mission vote, please wait for current vote to expire.", player);
+            _fetchedMissions = null;
             return false;
         }
-        _fetchedMissions = null;
         return true;
 
         void Action()
         {
             Globals.DedicatedServerManagerInstance.missionRotation.OverrideNext(_fetchedMissions![idx - 1]);
+            _fetchedMissions = null;
+
         }
     }
 


### PR DESCRIPTION
Clear fetched missions after vote expiration or action execution. Before, it would clear before the timer passes due to it being in a separate thread i believe