### PR TITLE
Support official dedicated server build

### DIFF
--- a/Nuclei/Features/Commands/CommandService.cs
+++ b/Nuclei/Features/Commands/CommandService.cs
@@ -38,7 +38,7 @@ public static class CommandService
     public static PermissionLevel GetPlayerPermissionLevel(Player player)
     {
         if (NucleiConfig.Owner!.Value == player.SteamID.ToString())
-            return PermissionLevel.Admin;
+            return PermissionLevel.Owner;
         
         if (NucleiConfig.AdminsList.Contains(player.SteamID.ToString()))
             return PermissionLevel.Admin;

--- a/Nuclei/Features/Commands/DefaultCommands/NewMissionCommand.cs
+++ b/Nuclei/Features/Commands/DefaultCommands/NewMissionCommand.cs
@@ -20,8 +20,8 @@ public class NewMissionCommand(ConfigFile config) : PermissionConfigurableComman
 
     public override bool Execute(Player player, string[] args)
     {
-        _ = Server.StartOrRestartLobby();
-        return true;
+        ChatService.SendPrivateChatMessage("The newmission command is disabled on the official dedicated server build.", player);
+        return false;
     }
 
     public override PermissionLevel DefaultPermissionLevel { get; } = PermissionLevel.Admin;

--- a/Nuclei/Features/MissionService.cs
+++ b/Nuclei/Features/MissionService.cs
@@ -47,7 +47,7 @@ public static class MissionService
     /// <summary>
     ///     The current mission time.
     /// </summary>
-    public static float CurrentMissionTime => Globals.MissionManagerInstance.missionTime;
+    public static float CurrentMissionTime => Globals.MissionManagerInstance.MissionTime;
 
     /// <summary>
     ///     Gets all Mission Keys as an IEnumerable.

--- a/Nuclei/Features/Server.cs
+++ b/Nuclei/Features/Server.cs
@@ -1,332 +1,46 @@
-using System.Linq;
-using System.Threading.Tasks;
-using Cysharp.Threading.Tasks;
-using NuclearOption.Networking;
-using NuclearOption.SavedMission;
-using Nuclei.Events;
 using Nuclei.Helpers;
 using UnityEngine;
 
 namespace Nuclei.Features;
 
 /// <summary>
-///     Server functionality for Nuclei.
+///     Server helpers for the official Nuclear Option dedicated server.
 /// </summary>
 public static class Server
 {
     /// <summary>
-    ///     Indicates whether the server is currently running.
+    ///     Indicates whether the dedicated server network layer is active.
     /// </summary>
     public static bool IsServerRunning => Globals.NetworkManagerNuclearOptionInstance.Server?.Active ?? false;
 
     /// <summary>
-    ///     The current mission time, calculated from the server's perspective.
+    ///     The current mission time, calculated from the dedicated server's mission manager.
     /// </summary>
-    public static double MissionTime => Globals.LocalPlayer.NetworkTime.Time;
-    
-    private static int _lastMotDSent;
-    
-    private static void CheckSendMotD()
-    {
-        if (NucleiConfig.MotDFrequency!.Value <= 0)
-            return;
-        
-        if (Time.time - _lastMotDSent < NucleiConfig.MotDFrequency!.Value && _lastMotDSent > 0)
-            return;
-        
-        ChatService.SendMotD();
-        _lastMotDSent = (int) Time.time;
-    }
-
-    private static void CheckMissionOverTime()
-    {
-        if (NucleiConfig.MissionDuration!.Value <= 0)
-            return;
-        
-        if (MissionTime < NucleiConfig.MissionDuration!.Value)
-            return;
-        
-        Nuclei.Logger?.LogInfo("Mission over-time reached, notifying players...");
-        ChatService.SendChatMessage("Mission over-time reached, ending mission prematurely...");
-        
-        _ = SlowlyEndMission();
-    }
-    
-    private static void OnMissionEnded(Mission mission)
-    {
-        Nuclei.Logger?.LogInfo($"Mission ended: {mission.Name}. Faction scores: {mission.factions.Aggregate("", (current, faction) => current + $"{faction.factionName}: {faction.FactionHQ.factionScore} ")}");
-        
-        _ = SlowlyEndMission();
-    }
-    
-    private static async UniTask SlowlyEndMission()
-    {
-        ChatService.SendChatMessage("Ending mission and starting a new one in 30 seconds...");
-        
-        await Task.Delay(20000);
-        
-        ChatService.SendChatMessage("Ending mission and starting a new one in 10 seconds...");
-        
-        await Task.Delay(10000);
-        
-        Nuclei.Logger?.LogInfo("Ending mission and starting a new one...");
-
-        await StartOrRestartLobby();
-    }
-    
-    private static void TimeStatus()
-    {
-        Nuclei.Logger?.LogInfo($"Mission time: {MissionTime} seconds ({MissionTime / 60} minutes)");
-        Nuclei.Logger?.LogInfo($"Remaining time: {NucleiConfig.MissionDuration!.Value - MissionTime} seconds ({(NucleiConfig.MissionDuration!.Value - MissionTime) / 60} minutes)");
-        Nuclei.Logger?.LogInfo($"Server FPS: {GetServerFPS()}");
-    }
+    public static double MissionTime => Globals.MissionManagerInstance.MissionTime;
 
     /// <summary>
     ///     Gets the current server FPS.
     /// </summary>
-    /// <returns> The current server FPS. </returns>
     public static double GetServerFPS()
     {
         return 1 / Time.unscaledDeltaTime;
     }
 
     /// <summary>
-    ///     Stops the dedicated server.
+    ///     Stops the dedicated server process.
     /// </summary>
     public static void StopServer()
     {
         Nuclei.Logger?.LogInfo("Stopping server...");
-        
-        EndMission();
-        
-        Task.Delay(3000).ContinueWith(_ =>
-        {
-            Nuclei.Logger?.LogInfo("Server stopped.");
-            Application.Quit();
-        });
+        ChatService.SendChatMessage("Server is stopping...");
+        Application.Quit();
     }
 
     /// <summary>
-    ///     Ends the current mission and returns the server to the main menu state.
+    ///     Mission restarts are handled by the official dedicated server runner.
     /// </summary>
-    public static void EndMission()
+    public static void StartOrRestartLobby()
     {
-        Nuclei.Logger?.LogInfo("Ending mission...");
-        
-        if (!IsServerRunning)
-        {
-            Nuclei.Logger?.LogWarning("Server is not running.");
-            return;
-        }
-        
-        MessageService.SendHostEndedMessage();
-        
-        Globals.NetworkManagerNuclearOptionInstance.Stop(false);
-        
-        SteamLobbyService.StopSteamLobby();
-        
-        Nuclei.Logger?.LogInfo("Mission ended.");
-    }
-
-    /// <summary>
-    ///     Select the next mission on the server, based on the server config's mission list and MissionSelectMode.
-    /// </summary>
-    public static void SelectNextMission()
-    {
-        Nuclei.Logger?.LogInfo("Selecting next mission...");
-
-        var mission = MissionService.GetNextMission(NucleiConfig.MissionSelectMode!.Value, NucleiConfig.UseAllMissions!.Value);
-        
-        if (mission == null)
-        {
-            Nuclei.Logger?.LogError("Failed to get a new mission.");
-            return;
-        }
-        
-        SelectMission(mission);
-    }
-
-    /// <summary>
-    ///     Select the given mission on the server.
-    /// </summary>
-    /// <param name="mission"> The mission to start. </param>
-    public static void SelectMission(Mission mission)
-    {
-        Nuclei.Logger?.LogInfo($"Selected mission: {mission.Name}");
-        
-        if (IsServerRunning)
-        {
-            Nuclei.Logger?.LogWarning("Server is already running.");
-            return;
-        }
-
-        MissionService.SetMission(mission);
-    }
-
-    /// <summary>
-    ///     Creates a <see cref="HostOptions" /> object based on the server config and the currently selected mission.
-    /// </summary>
-    /// <returns> The created <see cref="HostOptions" /> object. </returns>
-    public static HostOptions CreateHostOptionsForCurrentMission()
-    {
-        return CreateHostOptions(MissionService.CurrentMission!);
-    }
-
-    /// <summary>
-    ///     Creates a <see cref="HostOptions" /> object based on the server config and a given mission.
-    /// </summary>
-    /// <param name="mission"> The mission to create the <see cref="HostOptions" /> object for. </param>
-    /// <returns> The created <see cref="HostOptions" /> object. </returns>
-    public static HostOptions CreateHostOptions(Mission mission)
-    {
-        return new HostOptions
-        {
-            SocketType = NucleiConfig.UseSteamSocket!.Value ? SocketType.Steam : SocketType.UDP,
-            MaxConnections = NucleiConfig.MaxPlayers!.Value,
-            Map = mission.MapKey,
-            UdpPort = NucleiConfig.UseSteamSocket!.Value ? null : NucleiConfig.UdpPort!.Value
-        };
-    }
-
-    /// <summary>
-    ///     Starts a mission on the server, using the currently selected mission.
-    /// </summary>
-    public static async UniTask StartMission()
-    {
-        Nuclei.Logger?.LogInfo("Starting mission...");
-        
-        if (IsServerRunning)
-        {
-            Nuclei.Logger?.LogWarning("Server is already running.");
-            return;
-        }
-        
-        await Globals.NetworkManagerNuclearOptionInstance.StartHostAsync(CreateHostOptionsForCurrentMission());
-        
-        MissionEvents.OnNewMissionStarted(MissionService.CurrentMission!);
-        
-        Nuclei.Logger?.LogInfo("Mission started.");
-    }
-
-    /// <summary>
-    ///     Starts or restarts the lobby, selecting a random mission first.
-    /// </summary>
-    public static async UniTask StartOrRestartLobby()
-    {
-        if (IsServerRunning)
-        {
-            Nuclei.Logger?.LogInfo("Already running, ending mission first...");
-            EndMission();
-            await UniTask.WaitUntil(() => !Globals.NetworkManagerNuclearOptionInstance.stopping);
-        }
-        
-        GameManager.SetGameState(GameManager.GameState.Multiplayer);
-
-        if (MissionService.TryGetConsumePreselectedMission(out var mission))
-            SelectMission(mission!);
-        else
-            SelectNextMission();
-
-        await SteamLobbyService.StartSteamLobby();
-        await StartMission();
-        await SteamLobbyService.SetPingData();
-        SteamLobbyService.SetLobbyData();
-        
-        ApplyFramerateSettings();
-        ApplyExperimentalSettings();
-        
-        if (NucleiConfig.MuteAfterStart!.Value)
-            DisableAudio();
-
-        Resources.UnloadUnusedAssets();
-    }
-    
-    private static void DisableAudio()
-    {
-        Nuclei.Logger?.LogDebug("Disabling audio...");
-        
-        Globals.AudioMixerVolumeInstance.ChangeMixerVolume(AudioMixerVolume.Master, 0);
-
-        Nuclei.Logger?.LogDebug("Audio disabled.");
-    }
-
-    private static void ApplyFramerateSettings()
-    {
-        QualitySettings.SetQualityLevel(0, true);
-        QualitySettings.maxQueuedFrames = 0;
-        QualitySettings.vSyncCount = 0;
-        Application.targetFrameRate = NucleiConfig.TargetFrameRate!.Value;
-    }
-    
-    private static void ApplyExperimentalSettings()
-    {
-        if (NucleiConfig.UseUpdateForPhysicsUpdate!.Value)
-            Physics.simulationMode = SimulationMode.Update;
-        
-        if (NucleiConfig.PhysicsUpdatesPerSecond!.Value != 60)
-            Time.fixedDeltaTime = 1f / NucleiConfig.PhysicsUpdatesPerSecond!.Value;
-    }
-    
-    private static bool IsSteamManagerInitializedOrTimeout(float startTime)
-    {
-        return SteamManager.Initialized || Time.time - startTime > 10;
-    }
-
-    /// <summary>
-    ///     Starts the dedicated server.
-    /// </summary>
-    public static async UniTask StartServer()
-    {
-        if (IsServerRunning)
-        {
-            Nuclei.Logger?.LogWarning("Server is already running.");
-            return;
-        }
-        
-        Nuclei.Logger?.LogInfo("Starting server...");
-        
-        Nuclei.Logger?.LogDebug("Checking Steam API availability...");
-        
-        if (!SteamLobbyService.IsSteamAPIAvailable())
-        {
-            Nuclei.Logger?.LogError("Steam API is not available! Aborting server launch.");
-            return;
-        }
-
-        Nuclei.Logger?.LogDebug("Waiting for SteamManager to initialize...");
-        
-        var startTime = Time.time;
-        await UniTask.WaitUntil(() => IsSteamManagerInitializedOrTimeout(startTime));
-        
-        if (!SteamManager.Initialized)
-        {
-            Nuclei.Logger?.LogError("SteamManager failed to initialize within 10 seconds! Aborting server launch.");
-            return;
-        }
-        
-        Nuclei.Logger?.LogDebug("Validating mission config...");
-
-        if (!MissionService.ValidateMissionConfig())
-        {
-            Nuclei.Logger?.LogError("Failed to validate mission config! Aborting server launch.");
-            return;
-        }
-        
-        await StartOrRestartLobby();
-        
-        TimeService.Initialize();
-        
-        TimeEvents.EveryMinute += CheckSendMotD;
-        TimeEvents.EveryMinute += CheckMissionOverTime;
-        TimeEvents.Every10Minutes += TimeStatus;
-        MissionEvents.MissionEnded += OnMissionEnded;
-
-        if (NucleiConfig.RefreshServerNamePeriodically!.Value)
-        {
-            Nuclei.Logger?.LogDebug("Hooked up periodic server name refresh event.");
-            TimeEvents.Every10Minutes += SteamLobbyService.SetLobbyData;
-        }
-        
-        Nuclei.Logger?.LogInfo($"Server started. (Took {Time.time} seconds)");
+        Nuclei.Logger?.LogWarning("Mission restart is not implemented for the official dedicated server build.");
     }
 }

--- a/Nuclei/Features/SteamLobbyService.cs
+++ b/Nuclei/Features/SteamLobbyService.cs
@@ -1,84 +1,41 @@
 using Cysharp.Threading.Tasks;
-using Nuclei.Helpers;
-using Steamworks;
-using UnityEngine;
 
 namespace Nuclei.Features;
 
 /// <summary>
-///     Steam lobby wrapper service for Nuclei.
+///     Compatibility shim. Steam server advertisement is handled by the official dedicated server.
 /// </summary>
 public static class SteamLobbyService
 {
-    private const string KeyHostAddress = "HostAddress";
-    private const string KeyName = "name";
-    private const string KeyVersion = "version";
-    private const string KeyHostPing = "HostPing";
-
-    /// <summary>
-    ///     Starts a Steam lobby.
-    /// </summary>
-    public static async UniTask StartSteamLobby()
+    public static UniTask StartSteamLobby()
     {
-        Nuclei.Logger?.LogInfo("Starting Steam lobby...");
-
-        var result = await Globals.SteamLobbyInstance.Steam_CreateLobbyAsync(NucleiConfig.LobbyType!.Value,
-            NucleiConfig.MaxPlayers!.Value);
-        
-        if (result.m_eResult != EResult.k_EResultOK)
-        {
-            Nuclei.Logger?.LogError("Failed to create Steam lobby.");
-            return;
-        }
-        
-        Nuclei.Logger?.LogInfo("Steam lobby started.");
+        Nuclei.Logger?.LogDebug("Skipping Nuclei Steam lobby creation; official dedicated server owns advertisement.");
+        return UniTask.CompletedTask;
     }
+
     internal static void SetLobbyData()
     {
-        SteamMatchmaking.SetLobbyData(Globals.LobbySteamID, KeyHostAddress, SteamUser.GetSteamID().ToString());
-        SteamMatchmaking.SetLobbyData(Globals.LobbySteamID, KeyVersion, Application.version);
-        UpdateLobbyName();
+        Nuclei.Logger?.LogDebug("Skipping Nuclei Steam lobby data update; official dedicated server owns advertisement.");
     }
 
-    /// <summary>
-    ///     Updates the lobby name.
-    /// </summary>
-    /// <remarks> It is useful to re-run this periodically in case of dynamic placeholders. </remarks>
     public static void UpdateLobbyName()
     {
-        SteamMatchmaking.SetLobbyData(Globals.LobbySteamID, KeyName, DynamicPlaceholderUtils.ReplaceDynamicPlaceholders(NucleiConfig.ServerName!.Value));
+        Nuclei.Logger?.LogDebug("Skipping Nuclei Steam lobby name update; official dedicated server owns advertisement.");
     }
 
-    internal static async UniTask SetPingData()
+    internal static UniTask SetPingData()
     {
-        if (!await Globals.SteamLobbyInstance.WaitForLocalLocation())
-        {
-            Nuclei.Logger?.LogError("Failed to await Steam Lobby local location fetch for ping data. Ping will be empty.");
-            return;
-        }
-        if (SteamLobby.GetLocalLocation(out var location))
-            SteamMatchmaking.SetLobbyData(Globals.LobbySteamID, KeyHostPing, location);
-        else
-            Nuclei.Logger?.LogError("Failed to get local location for ping data. Ping will be empty.");
+        Nuclei.Logger?.LogDebug("Skipping Nuclei Steam lobby ping data update; official dedicated server owns advertisement.");
+        return UniTask.CompletedTask;
     }
-    
-    /// <summary>
-    ///     Stops the Steam lobby.
-    /// </summary>
+
     public static void StopSteamLobby()
     {
-        Nuclei.Logger?.LogDebug("Stopping Steam lobby...");
-        SteamMatchmaking.LeaveLobby(Globals.LobbySteamID);
-        Nuclei.Logger?.LogDebug("Steam lobby stopped.");
+        Nuclei.Logger?.LogDebug("Skipping Nuclei Steam lobby shutdown; official dedicated server owns advertisement.");
     }
-    
-    /// <summary>
-    ///     Checks if the Steam API is available.
-    /// </summary>
-    /// <returns> True if the Steam API is available, false otherwise. </returns>
+
     public static bool IsSteamAPIAvailable()
     {
-        return SteamAPI.IsSteamRunning();
+        return true;
     }
-    
 }

--- a/Nuclei/GlobalUsings.cs
+++ b/Nuclei/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using NuclearOption.Chat;
+global using NuclearOption.Networking;
+global using NuclearOption.Networking.Lobbies;

--- a/Nuclei/Helpers/Globals.cs
+++ b/Nuclei/Helpers/Globals.cs
@@ -34,7 +34,7 @@ public static class Globals
     /// <summary>
     ///     Gets the local player. (The host / server)
     /// </summary>
-    public static Player LocalPlayer => GameManager.LocalPlayer ?? throw new NullReferenceException("Local player is null.");
+    public static Player LocalPlayer => GameManager.GetLocalPlayer<Player>(out var localPlayer) ? localPlayer : throw new NullReferenceException("Local player is null.");
 
     /// <summary>
     ///     Gets the instance of the <see cref="AudioMixerVolume" /> class.
@@ -49,7 +49,7 @@ public static class Globals
     /// <summary>
     ///     Gets the Steam ID of the lobby.
     /// </summary>
-    public static CSteamID LobbySteamID => SteamLobbyInstance._currentLobbyID;
+    public static CSteamID LobbySteamID => throw new NotSupportedException("Nuclei no longer manages Steam lobbies on the official dedicated server.");
 
     /// <summary>
     ///     Get a read-only list of all authenticated players.

--- a/Nuclei/Patches/CSteamAPIContextPatches.cs
+++ b/Nuclei/Patches/CSteamAPIContextPatches.cs
@@ -1,6 +1,4 @@
-using System;
 using HarmonyLib;
-using Nuclei.Features;
 using Steamworks;
 
 namespace Nuclei.Patches;
@@ -14,13 +12,6 @@ internal static class CSteamAPIContextPatches
     [HarmonyPatch(nameof(CSteamAPIContext.Init))]
     private static void InitPostfix()
     {
-        try
-        {
-            _ = Server.StartServer();
-        }
-        catch (Exception e)
-        {
-            Nuclei.Logger?.LogError($"Aborting server launch: Failed to start the server. For more information, see this error trace:\n{e}");
-        }
+        Nuclei.Logger?.LogInfo("Steam API context initialized; attaching Nuclei to the official dedicated server.");
     }
 }

--- a/Nuclei/Patches/ChatManagerPatches.cs
+++ b/Nuclei/Patches/ChatManagerPatches.cs
@@ -12,8 +12,8 @@ namespace Nuclei.Patches;
 internal static class ChatManagerPatches
 {
     [HarmonyPrefix]
-    [HarmonyPatch(nameof(ChatManager.UserCode_CmdSendChatMessage_1323305531))]
-    private static bool UserCode_CmdSendChatMessage_1323305531Prefix(string message, bool allChat, INetworkPlayer sender)
+    [HarmonyPatch("UserCode_CmdSendChatMessage_-456754112")]
+    private static bool UserCode_CmdSendChatMessagePrefix(string message, bool allChat, INetworkPlayer sender)
     {
         if (!sender.TryGetPlayer(out var player)) 
             Nuclei.Logger?.LogWarning("Player component is null");


### PR DESCRIPTION
# Support current official Nuclear Option dedicated server build

## Summary

This ports Nuclei to load on the current official Nuclear Option dedicated server build tested against:

- Nuclear Option dedicated server `0.33.3`
- Linux/headless
- BepInEx `5.4.23.5`
- Nuclei `v1.3.3` / current `master` at `2159beb`

The release DLL fails to chainload on this server, and current `master` needs API/namespace updates plus a different startup model because the official dedicated server now owns Steam server advertisement and mission rotation through `DedicatedServerManager` / `DedicatedServerConfig.json`.

## What changed

- Add global usings for moved Nuclear Option namespaces:
  - `NuclearOption.Chat`
  - `NuclearOption.Networking`
  - `NuclearOption.Networking.Lobbies`
- Update the chat Harmony target to the current generated metadata name:
  - `UserCode_CmdSendChatMessage_-456754112`
- Update changed game APIs:
  - `MissionManager.missionTime` -> `MissionManager.MissionTime`
  - `GameManager.LocalPlayer` -> `GameManager.GetLocalPlayer<Player>(out ...)`
- Stop Nuclei from creating/managing its own Steam lobby/server on the official dedicated server path.
- Replace old lobby operations with no-op compatibility shims, because official dedicated server advertisement is already handled by the game.
- Make `/stop` quit the official dedicated server process cleanly.
- Disable `/newmission` for now on the official dedicated server path, with a private chat message explaining that mission loading is owned by the official dedicated server runner.
- Fix owner permissions so configured owner receives `PermissionLevel.Owner`, not `PermissionLevel.Admin`.

## Why this shape

The official dedicated server appears to be the authoritative owner of:

- Steam game-server advertisement
- max player count / ports / password
- mission rotation
- map loading
- no-player stop behavior

So this patch makes Nuclei attach to the official server lifecycle instead of trying to launch a second legacy host/lobby path.

## Verification

Build:

```text
Nuclei -> bin/Release/net48/MaxWasUnavailable.Nuclei.dll
Build succeeded.
0 Error(s)
```

Runtime verification on both dedicated server instances:

```text
[Info   :   BepInEx] Loading [MaxWasUnavailable.Nuclei 1.3.3]
[Info   :MaxWasUnavailable.Nuclei] Loading MaxWasUnavailable.Nuclei v1.3.3...
[Info   :MaxWasUnavailable.Nuclei] Plugin MaxWasUnavailable.Nuclei is loaded!
```

The tested server continued advertising and accepting the official dedicated server configuration through the base game server manager.

## Known limitations

- `/newmission` is intentionally disabled in this patch because mission switching should be reimplemented against the official `DedicatedServerManager` rather than the removed legacy lobby/server path.
- This is a compatibility port for the official dedicated server path; it may need additional conditionals if Nuclei still wants to support older client-hosted server flows.